### PR TITLE
Feature/POPUG-14 Implemented listener for business TaskCreatedEvent

### DIFF
--- a/employee-billing/build.gradle.kts
+++ b/employee-billing/build.gradle.kts
@@ -16,6 +16,7 @@ val mapstructVersion: String by project
 val lombokVersion: String by project
 val liquibaseVersion: String by project
 val postgresVersion: String by project
+val uuidCreatorVersion: String by project
 
 repositories {
     mavenCentral()
@@ -45,6 +46,8 @@ dependencies {
     implementation("org.liquibase:liquibase-core:${liquibaseVersion}")
     // PostgreSQL.
     implementation("org.postgresql:postgresql:${postgresVersion}")
+    // UUID creator library.
+    implementation("com.github.f4b6a3:uuid-creator:${uuidCreatorVersion}")
 
 
     // --> Compile-Only Dependencies <--

--- a/employee-billing/gradle.properties
+++ b/employee-billing/gradle.properties
@@ -1,3 +1,6 @@
+# --> Util Libraries <--
+uuidCreatorVersion=5.3.7
+
 # --> Lombok <--
 lombokVersion=1.18.30
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/BillingServicesConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/BillingServicesConfig.java
@@ -1,0 +1,132 @@
+package org.uber.popug.employee.billing.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.uber.popug.employee.billing.domain.aggregates.BillingCycleProvider;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.aggregates.impl.BillingCycleProviderImpl;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationDescriptionBuilder;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationIdProvider;
+import org.uber.popug.employee.billing.domain.billing.operation.impl.BillingOperationIdProviderImpl;
+import org.uber.popug.employee.billing.domain.billing.operation.impl.TaskWithAssigneeBillingOperationDescriptionBuilder;
+import org.uber.popug.employee.billing.mapping.BillingAccountsPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.BillingCyclesPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
+import org.uber.popug.employee.billing.mapping.TasksPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.UsersPersistenceMapper;
+import org.uber.popug.employee.billing.repository.BillingAccountRepository;
+import org.uber.popug.employee.billing.repository.BillingCycleRepository;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
+import org.uber.popug.employee.billing.repository.TaskRepository;
+import org.uber.popug.employee.billing.repository.UserRepository;
+import org.uber.popug.employee.billing.service.BillingAccountManagementService;
+import org.uber.popug.employee.billing.service.BillingOperationLogService;
+import org.uber.popug.employee.billing.service.TaskBillingOperationAssemblingService;
+import org.uber.popug.employee.billing.service.TransactionalAccountingService;
+import org.uber.popug.employee.billing.service.UserAccountBillingService;
+import org.uber.popug.employee.billing.service.UserAccountMembershipCheckingService;
+import org.uber.popug.employee.billing.service.impl.BillingAccountManagementServiceImpl;
+import org.uber.popug.employee.billing.service.impl.BillingOperationLogServiceImpl;
+import org.uber.popug.employee.billing.service.impl.TaskBillingOperationAssemblingServiceImpl;
+import org.uber.popug.employee.billing.service.impl.TransactionalAccountingServiceImpl;
+import org.uber.popug.employee.billing.service.impl.UserAccountBillingServiceImpl;
+import org.uber.popug.employee.billing.service.impl.UserAccountMembershipCheckingServiceImpl;
+
+@Configuration(proxyBeanMethods = false)
+public class BillingServicesConfig {
+
+    @Bean
+    public BillingOperationIdProvider billingOperationIdProvider(
+            ImmutableBillingOperationsRepository billingOperationsRepository
+    ) {
+        return new BillingOperationIdProviderImpl(billingOperationsRepository);
+    }
+
+    @Bean
+    public BillingOperationDescriptionBuilder<TaskWithAssignee> taskWithAssigneeDescriptionBuilder() {
+        return new TaskWithAssigneeBillingOperationDescriptionBuilder();
+    }
+
+    @Bean
+    public TaskBillingOperationAssemblingService taskBillingOperationAssemblingService(
+            BillingOperationIdProvider billingOperationIdProvider,
+            BillingOperationDescriptionBuilder<TaskWithAssignee> taskWithAssigneeDescriptionBuilder
+    ) {
+        return new TaskBillingOperationAssemblingServiceImpl(
+                billingOperationIdProvider,
+                taskWithAssigneeDescriptionBuilder
+        );
+    }
+
+    @Bean
+    public BillingCycleProvider billingCycleProvider(
+            BillingCycleRepository billingCycleRepository,
+            BillingCyclesPersistenceMapper billingCyclesPersistenceMapper
+    ) {
+        return new BillingCycleProviderImpl(billingCycleRepository, billingCyclesPersistenceMapper);
+    }
+
+    @Bean
+    public BillingOperationLogService billingOperationLogService(
+            TaskBillingOperationAssemblingService billingOperationAssemblingService,
+            BillingCycleProvider billingCycleProvider,
+            BillingOperationsPersistenceMapper billingOperationsPersistenceMapper,
+            ImmutableBillingOperationsRepository billingOperationsRepository
+    ) {
+        return new BillingOperationLogServiceImpl(
+                billingOperationAssemblingService,
+                billingCycleProvider,
+                billingOperationsPersistenceMapper,
+                billingOperationsRepository
+        );
+    }
+
+    @Bean
+    public UserAccountMembershipCheckingService userAccountMembershipCheckingService(
+            TaskRepository taskRepository,
+            UserRepository userRepository,
+            TasksPersistenceMapper tasksPersistenceMapper,
+            UsersPersistenceMapper usersPersistenceMapper
+    ) {
+        return new UserAccountMembershipCheckingServiceImpl(
+                taskRepository,
+                userRepository,
+                tasksPersistenceMapper,
+                usersPersistenceMapper
+        );
+    }
+
+    @Bean
+    public BillingAccountManagementService billingAccountManagementService(
+            BillingAccountRepository billingAccountRepository,
+            BillingAccountsPersistenceMapper billingAccountsPersistenceMapper
+    ) {
+        return new BillingAccountManagementServiceImpl(billingAccountRepository, billingAccountsPersistenceMapper);
+    }
+
+    @Bean
+    public TransactionalAccountingService transactionalAccountingService(
+            BillingOperationLogService billingOperationLogService,
+            BillingAccountManagementService billingAccountManagementService
+    ) {
+        return new TransactionalAccountingServiceImpl(
+                billingOperationLogService,
+                billingAccountManagementService
+        );
+    }
+
+    @Bean
+    public UserAccountBillingService userAccountBillingService(
+            TasksBusinessKafkaEventMapper tasksBusinessKafkaEventMapper,
+            UserAccountMembershipCheckingService accountMembershipCheckingService,
+            TransactionalAccountingService transactionalAccountingService
+    ) {
+        return new UserAccountBillingServiceImpl(
+                tasksBusinessKafkaEventMapper,
+                accountMembershipCheckingService,
+                transactionalAccountingService
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/KafkaConsumerConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/KafkaConsumerConfig.java
@@ -2,6 +2,7 @@ package org.uber.popug.employee.billing.config;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,7 +24,7 @@ public class KafkaConsumerConfig {
     @Value("${kafka.listener.task-workflow-actions.bootstrap-servers}")
     private List<String> taskWorkflowActionsBootstrapServers;
 
-    @Bean
+    @Bean("tasksCUDConsumerFactory")
     public ConsumerFactory<String, Object> tasksCUDConsumerFactory() {
         final var taskCUDStreamConsumerProps = Map.<String, Object>ofEntries(
                 Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, taskLifecycleStreamBootstrapServers)
@@ -36,17 +37,17 @@ public class KafkaConsumerConfig {
         );
     }
 
-    @Bean
+    @Bean("tasksCUDListenerContainerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, Object>
     tasksCUDListenerContainerFactory(
-            ConsumerFactory<String, Object> tasksCUDConsumerFactory
+            @Qualifier("tasksCUDConsumerFactory") ConsumerFactory<String, Object> consumerFactory
     ) {
         final var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
-        factory.setConsumerFactory(tasksCUDConsumerFactory);
+        factory.setConsumerFactory(consumerFactory);
         return factory;
     }
 
-    @Bean
+    @Bean("tasksBusinessWorkflowConsumerFactory")
     public ConsumerFactory<String, Object> tasksBusinessWorkflowConsumerFactory() {
         final var taskBusinessConsumerProps = Map.<String, Object>ofEntries(
                 Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, taskWorkflowActionsBootstrapServers)
@@ -59,13 +60,13 @@ public class KafkaConsumerConfig {
         );
     }
 
-    @Bean
+    @Bean("tasksBusinessWorkflowListenerContainerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, Object>
     tasksBusinessWorkflowListenerContainerFactory(
-            ConsumerFactory<String, Object> tasksBusinessWorkflowConsumerFactory
+            @Qualifier("tasksBusinessWorkflowConsumerFactory") ConsumerFactory<String, Object> consumerFactory
     ) {
         var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
-        factory.setConsumerFactory(tasksBusinessWorkflowConsumerFactory);
+        factory.setConsumerFactory(consumerFactory);
         return factory;
     }
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/KafkaConsumerConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/KafkaConsumerConfig.java
@@ -8,9 +8,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.uber.popug.employee.billing.kafka.CustomTasksCUDJsonDeserializer;
+import org.uber.popug.employee.billing.kafka.TasksBusinessWorkflowJsonDeserializer;
+import org.uber.popug.employee.billing.kafka.TasksCUDJsonDeserializer;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -20,16 +20,19 @@ public class KafkaConsumerConfig {
     @Value("${kafka.listener.task-lifecycle-stream.bootstrap-servers}")
     private List<String> taskLifecycleStreamBootstrapServers;
 
+    @Value("${kafka.listener.task-workflow-actions.bootstrap-servers}")
+    private List<String> taskWorkflowActionsBootstrapServers;
+
     @Bean
     public ConsumerFactory<String, Object> tasksCUDConsumerFactory() {
-        Map<String, Object> taskCUDStreamConsumerProps = new HashMap<>();
-        taskCUDStreamConsumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, taskLifecycleStreamBootstrapServers);
-
+        final var taskCUDStreamConsumerProps = Map.<String, Object>ofEntries(
+                Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, taskLifecycleStreamBootstrapServers)
+        );
 
         return new DefaultKafkaConsumerFactory<>(
                 taskCUDStreamConsumerProps,
                 StringDeserializer::new,
-                CustomTasksCUDJsonDeserializer::new
+                TasksCUDJsonDeserializer::new
         );
     }
 
@@ -38,10 +41,31 @@ public class KafkaConsumerConfig {
     tasksCUDListenerContainerFactory(
             ConsumerFactory<String, Object> tasksCUDConsumerFactory
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-
+        final var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
         factory.setConsumerFactory(tasksCUDConsumerFactory);
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> tasksBusinessWorkflowConsumerFactory() {
+        final var taskBusinessConsumerProps = Map.<String, Object>ofEntries(
+                Map.entry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, taskWorkflowActionsBootstrapServers)
+        );
+
+        return new DefaultKafkaConsumerFactory<>(
+                taskBusinessConsumerProps,
+                StringDeserializer::new,
+                TasksBusinessWorkflowJsonDeserializer::new
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object>
+    tasksBusinessWorkflowListenerContainerFactory(
+            ConsumerFactory<String, Object> tasksBusinessWorkflowConsumerFactory
+    ) {
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, Object>();
+        factory.setConsumerFactory(tasksBusinessWorkflowConsumerFactory);
         return factory;
     }
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
@@ -3,6 +3,7 @@ package org.uber.popug.employee.billing.config;
 import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksCUDKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksPersistenceMapper;
@@ -12,11 +13,6 @@ import org.uber.popug.employee.billing.mapping.UsersPersistenceMapper;
 public class MappersConfig {
 
     @Bean
-    public TasksCUDKafkaEventMapper tasksCUDKafkaEventMapper() {
-        return Mappers.getMapper(TasksCUDKafkaEventMapper.class);
-    }
-
-    @Bean
     public UsersPersistenceMapper usersPersistenceMapper() {
         return Mappers.getMapper(UsersPersistenceMapper.class);
     }
@@ -24,6 +20,16 @@ public class MappersConfig {
     @Bean
     public TasksPersistenceMapper tasksPersistenceMapper() {
         return Mappers.getMapper(TasksPersistenceMapper.class);
+    }
+
+    @Bean
+    public BillingOperationsPersistenceMapper billingOperationsPersistenceMapper() {
+        return Mappers.getMapper(BillingOperationsPersistenceMapper.class);
+    }
+
+    @Bean
+    public TasksCUDKafkaEventMapper tasksCUDKafkaEventMapper() {
+        return Mappers.getMapper(TasksCUDKafkaEventMapper.class);
     }
 
     @Bean

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
@@ -3,6 +3,7 @@ package org.uber.popug.employee.billing.config;
 import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksCUDKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.UsersPersistenceMapper;
@@ -21,8 +22,13 @@ public class MappersConfig {
     }
 
     @Bean
-    TasksPersistenceMapper tasksPersistenceMapper() {
+    public TasksPersistenceMapper tasksPersistenceMapper() {
         return Mappers.getMapper(TasksPersistenceMapper.class);
+    }
+
+    @Bean
+    public TasksBusinessKafkaEventMapper tasksBusinessKafkaEventMapper() {
+        return Mappers.getMapper(TasksBusinessKafkaEventMapper.class);
     }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
@@ -4,6 +4,7 @@ import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uber.popug.employee.billing.mapping.BillingAccountsPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.BillingCyclesPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksCUDKafkaEventMapper;
@@ -31,6 +32,11 @@ public class MappersConfig {
     @Bean
     public BillingAccountsPersistenceMapper billingAccountsPersistenceMapper() {
         return Mappers.getMapper(BillingAccountsPersistenceMapper.class);
+    }
+
+    @Bean
+    public BillingCyclesPersistenceMapper billingCyclesPersistenceMapper() {
+        return Mappers.getMapper(BillingCyclesPersistenceMapper.class);
     }
 
     @Bean

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/MappersConfig.java
@@ -3,6 +3,7 @@ package org.uber.popug.employee.billing.config;
 import org.mapstruct.factory.Mappers;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.uber.popug.employee.billing.mapping.BillingAccountsPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
 import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
 import org.uber.popug.employee.billing.mapping.TasksCUDKafkaEventMapper;
@@ -25,6 +26,11 @@ public class MappersConfig {
     @Bean
     public BillingOperationsPersistenceMapper billingOperationsPersistenceMapper() {
         return Mappers.getMapper(BillingOperationsPersistenceMapper.class);
+    }
+
+    @Bean
+    public BillingAccountsPersistenceMapper billingAccountsPersistenceMapper() {
+        return Mappers.getMapper(BillingAccountsPersistenceMapper.class);
     }
 
     @Bean

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/config/RepositoriesConfig.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/config/RepositoriesConfig.java
@@ -3,8 +3,14 @@ package org.uber.popug.employee.billing.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.uber.popug.employee.billing.repository.BillingAccountRepository;
+import org.uber.popug.employee.billing.repository.BillingCycleRepository;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
 import org.uber.popug.employee.billing.repository.TaskRepository;
 import org.uber.popug.employee.billing.repository.UserRepository;
+import org.uber.popug.employee.billing.repository.impl.JdbcClientBillingAccountRepository;
+import org.uber.popug.employee.billing.repository.impl.JdbcClientBillingCycleRepository;
+import org.uber.popug.employee.billing.repository.impl.JdbcClientImmutableBillingOperationsRepository;
 import org.uber.popug.employee.billing.repository.impl.JdbcClientTaskRepository;
 import org.uber.popug.employee.billing.repository.impl.JdbcClientUserRepository;
 
@@ -12,17 +18,28 @@ import org.uber.popug.employee.billing.repository.impl.JdbcClientUserRepository;
 public class RepositoriesConfig {
 
     @Bean
-    public TaskRepository taskRepository(
-            JdbcClient jdbcClient
-    ) {
+    public TaskRepository taskRepository(JdbcClient jdbcClient) {
         return new JdbcClientTaskRepository(jdbcClient);
     }
 
     @Bean
-    public UserRepository userRepository(
-            JdbcClient jdbcClient
-    ) {
+    public UserRepository userRepository(JdbcClient jdbcClient) {
         return new JdbcClientUserRepository(jdbcClient);
+    }
+
+    @Bean
+    public ImmutableBillingOperationsRepository billingOperationsRepository(JdbcClient jdbcClient) {
+        return new JdbcClientImmutableBillingOperationsRepository(jdbcClient);
+    }
+
+    @Bean
+    public BillingAccountRepository billingAccountRepository(JdbcClient jdbcClient) {
+        return new JdbcClientBillingAccountRepository(jdbcClient);
+    }
+
+    @Bean
+    public BillingCycleRepository billingCycleRepository(JdbcClient jdbcClient) {
+        return new JdbcClientBillingCycleRepository(jdbcClient);
     }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingAccountWithOwner.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingAccountWithOwner.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.domain.aggregates;
+
+import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.domain.billing.account.BillingAccount;
+import org.uber.popug.employee.billing.domain.user.User;
+
+public record BillingAccountWithOwner(
+        @Nonnull BillingAccount account,
+        @Nonnull User owner
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingCycleProvider.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingCycleProvider.java
@@ -1,0 +1,9 @@
+package org.uber.popug.employee.billing.domain.aggregates;
+
+import org.uber.popug.employee.billing.domain.billing.cycle.BillingCycle;
+
+public interface BillingCycleProvider {
+
+    BillingCycle retrieveActiveBillingCycle();
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingOperationFullData.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/BillingOperationFullData.java
@@ -1,0 +1,26 @@
+package org.uber.popug.employee.billing.domain.aggregates;
+
+import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.domain.billing.cycle.BillingCycle;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperation;
+import org.uber.popug.employee.billing.domain.user.User;
+
+public record BillingOperationFullData(
+        @Nonnull BillingOperation data,
+        @Nonnull User ownerUser,
+        @Nonnull BillingCycle ownerCycle
+) {
+
+    public static BillingOperationFullData assembleBillingOperationLogEntry(
+            BillingOperation billingOperation,
+            User ownerUser,
+            BillingCycleProvider billingCycleProvider
+    ) {
+        return new BillingOperationFullData(
+                billingOperation,
+                ownerUser,
+                billingCycleProvider.retrieveActiveBillingCycle()
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/PaymentDataWithUser.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/PaymentDataWithUser.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.domain.aggregates;
+
+import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.domain.billing.PaymentData;
+import org.uber.popug.employee.billing.domain.user.User;
+
+public record PaymentDataWithUser(
+        @Nonnull PaymentData data,
+        @Nonnull User relatedUser
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/impl/BillingCycleProviderImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/aggregates/impl/BillingCycleProviderImpl.java
@@ -1,0 +1,25 @@
+package org.uber.popug.employee.billing.domain.aggregates.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.aggregates.BillingCycleProvider;
+import org.uber.popug.employee.billing.domain.billing.cycle.BillingCycle;
+import org.uber.popug.employee.billing.exception.technical.NoActiveBillingCycleAvailableException;
+import org.uber.popug.employee.billing.mapping.BillingCyclesPersistenceMapper;
+import org.uber.popug.employee.billing.repository.BillingCycleRepository;
+
+@RequiredArgsConstructor
+public class BillingCycleProviderImpl implements BillingCycleProvider {
+
+    private final BillingCycleRepository billingCycleRepository;
+    private final BillingCyclesPersistenceMapper billingCyclesPersistenceMapper;
+
+    @Override
+    public BillingCycle retrieveActiveBillingCycle() {
+        final var activeBillingCycleEntity = billingCycleRepository.findActiveBillingCycle().orElseThrow(
+                NoActiveBillingCycleAvailableException::forNowUTC
+        );
+
+        return billingCyclesPersistenceMapper.toBusiness(activeBillingCycleEntity);
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/PaymentData.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/PaymentData.java
@@ -1,0 +1,7 @@
+package org.uber.popug.employee.billing.domain.billing;
+
+public record PaymentData(
+        long credit,
+        long debit
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/PaymentData.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/PaymentData.java
@@ -4,4 +4,9 @@ public record PaymentData(
         long credit,
         long debit
 ) {
+
+    public static PaymentData newCreditData(long credit) {
+        return new PaymentData(credit, 0L);
+    }
+
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/account/BillingAccount.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/account/BillingAccount.java
@@ -1,0 +1,12 @@
+package org.uber.popug.employee.billing.domain.billing.account;
+
+import jakarta.annotation.Nonnull;
+
+import java.util.UUID;
+
+public record BillingAccount(
+        long id,
+        @Nonnull UUID publicId,
+        long currentTotal
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/creation/TaskForBillingAssignment.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/creation/TaskForBillingAssignment.java
@@ -1,14 +1,13 @@
-package org.uber.popug.employee.billing.domain.task.creation;
+package org.uber.popug.employee.billing.domain.billing.creation;
 
 import jakarta.annotation.Nonnull;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record TaskForCreation(
+public record TaskForBillingAssignment(
         @Nonnull UUID id,
         @Nonnull UUID assigneeId,
-        @Nonnull String description,
         @Nonnull LocalDateTime creationDate
 ) {
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/creation/TaskForBillingAssignment.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/creation/TaskForBillingAssignment.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record TaskForBillingAssignment(
-        @Nonnull UUID id,
+        @Nonnull UUID publicId,
         @Nonnull UUID assigneeId,
         @Nonnull LocalDateTime creationDate
 ) {

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/cycle/BillingCycle.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/cycle/BillingCycle.java
@@ -1,0 +1,23 @@
+package org.uber.popug.employee.billing.domain.billing.cycle;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BillingCycle(
+        long id,
+        @Nonnull UUID publicId,
+        @Nonnull LocalDateTime startDate,
+        @Nonnull LocalDateTime endDate,
+        @Nonnull State state
+) {
+    @Getter
+    @RequiredArgsConstructor
+    public enum State {
+        ACTIVE,
+        CLOSED
+    }
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
@@ -23,7 +23,7 @@ public record BillingOperation(
                 billingOperationIdProvider.generatePublicBillingOperationId(),
                 billingOperationDescriptionBuilder.buildBillingOperationDescription(taskWithAssignee),
                 new PaymentData(
-                        taskWithAssignee.task().assignmentCost(),
+                        taskWithAssignee.task().costs().assignmentCost(),
                         0L
                 )
         );

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
@@ -2,6 +2,7 @@ package org.uber.popug.employee.billing.domain.billing.operation;
 
 import jakarta.annotation.Nonnull;
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.PaymentData;
 
 import java.util.UUID;
 
@@ -9,8 +10,7 @@ public record BillingOperation(
         long id,
         @Nonnull UUID publicId,
         @Nonnull String description,
-        long credit,
-        long debit
+        @Nonnull PaymentData paymentData
 ) {
 
     public static BillingOperation forTaskWithAssignee(
@@ -22,8 +22,10 @@ public record BillingOperation(
                 billingOperationIdProvider.generateDbBillingOperationId(),
                 billingOperationIdProvider.generatePublicBillingOperationId(),
                 billingOperationDescriptionBuilder.buildBillingOperationDescription(taskWithAssignee),
-                taskWithAssignee.task().assignmentCost(),
-                0L
+                new PaymentData(
+                        taskWithAssignee.task().assignmentCost(),
+                        0L
+                )
         );
     }
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperation.java
@@ -1,0 +1,30 @@
+package org.uber.popug.employee.billing.domain.billing.operation;
+
+import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+
+import java.util.UUID;
+
+public record BillingOperation(
+        long id,
+        @Nonnull UUID publicId,
+        @Nonnull String description,
+        long credit,
+        long debit
+) {
+
+    public static BillingOperation forTaskWithAssignee(
+            BillingOperationIdProvider billingOperationIdProvider,
+            BillingOperationDescriptionBuilder<TaskWithAssignee> billingOperationDescriptionBuilder,
+            TaskWithAssignee taskWithAssignee
+    ) {
+        return new BillingOperation(
+                billingOperationIdProvider.generateDbBillingOperationId(),
+                billingOperationIdProvider.generatePublicBillingOperationId(),
+                billingOperationDescriptionBuilder.buildBillingOperationDescription(taskWithAssignee),
+                taskWithAssignee.task().assignmentCost(),
+                0L
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperationDescriptionBuilder.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperationDescriptionBuilder.java
@@ -1,0 +1,8 @@
+package org.uber.popug.employee.billing.domain.billing.operation;
+
+@FunctionalInterface
+public interface BillingOperationDescriptionBuilder<T> {
+
+    String buildBillingOperationDescription(T operationDescriptionSource);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperationIdProvider.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/BillingOperationIdProvider.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.domain.billing.operation;
+
+import java.util.UUID;
+
+public interface BillingOperationIdProvider {
+
+    UUID generatePublicBillingOperationId();
+
+    long generateDbBillingOperationId();
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/impl/BillingOperationIdProviderImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/impl/BillingOperationIdProviderImpl.java
@@ -1,0 +1,25 @@
+package org.uber.popug.employee.billing.domain.billing.operation.impl;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationIdProvider;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class BillingOperationIdProviderImpl implements BillingOperationIdProvider {
+
+    private final ImmutableBillingOperationsRepository billingOperationsRepository;
+
+    @Override
+    public UUID generatePublicBillingOperationId() {
+        return UuidCreator.getTimeOrderedEpoch();
+    }
+
+    @Override
+    public long generateDbBillingOperationId() {
+        return billingOperationsRepository.generateNextDbBillingOperationId();
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/impl/TaskWithAssigneeBillingOperationDescriptionBuilder.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/billing/operation/impl/TaskWithAssigneeBillingOperationDescriptionBuilder.java
@@ -1,0 +1,25 @@
+package org.uber.popug.employee.billing.domain.billing.operation.impl;
+
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationDescriptionBuilder;
+
+public class TaskWithAssigneeBillingOperationDescriptionBuilder
+        implements BillingOperationDescriptionBuilder<TaskWithAssignee> {
+
+    private static final String TASK_ASSIGNED_LOG_OPERATION_DESCRIPTION_MESSAGE_TEMPLATE
+            = "[Task assigned] User with id %s, login %s was assigned a task with id = %s and description: %s, " +
+              "which costed %d$.";
+
+    @Override
+    public String buildBillingOperationDescription(TaskWithAssignee operationDescriptionSource) {
+        return TASK_ASSIGNED_LOG_OPERATION_DESCRIPTION_MESSAGE_TEMPLATE
+                .formatted(
+                        operationDescriptionSource.assignee().extPublicId(),
+                        operationDescriptionSource.assignee().login(),
+                        operationDescriptionSource.task().extPublicId(),
+                        operationDescriptionSource.task().description(),
+                        operationDescriptionSource.task().costs().assignmentCost()
+                );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/Task.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/Task.java
@@ -10,12 +10,17 @@ public record Task(
         @Nonnull UUID extPublicId,
         @Nonnull String description,
         @Nonnull Status status,
-        long assignmentCost,
-        long completionCost
-) {
+        @Nonnull Costs costs
+        ) {
     public enum Status {
         OPEN,
         COMPLETED
+    }
+
+    public record Costs(
+            long assignmentCost,
+            long completionCost
+    ) {
     }
 
     public static Task replicate(
@@ -28,8 +33,10 @@ public record Task(
                 taskReplicationInfo.id(),
                 taskReplicationInfo.description(),
                 Status.OPEN,
-                taskCostsProvider.calculateAssignmentCost(),
-                taskCostsProvider.calculateCompletionCost()
+                new Costs(
+                        taskCostsProvider.calculateAssignmentCost(),
+                        taskCostsProvider.calculateCompletionCost()
+                )
         );
     }
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/Task.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/Task.java
@@ -1,6 +1,7 @@
 package org.uber.popug.employee.billing.domain.task;
 
 import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.domain.task.replication.TaskReplicationInfo;
 
 import java.util.UUID;
 
@@ -20,12 +21,12 @@ public record Task(
     public static Task replicate(
             @Nonnull TaskIdProvider taskIdProvider,
             @Nonnull TaskCostsProvider taskCostsProvider,
-            @Nonnull TaskInfo taskInfo
+            @Nonnull TaskReplicationInfo taskReplicationInfo
     ) {
         return new Task(
                 taskIdProvider.generateDbTaskId(),
-                taskInfo.id(),
-                taskInfo.description(),
+                taskReplicationInfo.id(),
+                taskReplicationInfo.description(),
                 Status.OPEN,
                 taskCostsProvider.calculateAssignmentCost(),
                 taskCostsProvider.calculateCompletionCost()

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/creation/TaskForCreation.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/creation/TaskForCreation.java
@@ -1,0 +1,14 @@
+package org.uber.popug.employee.billing.domain.task.creation;
+
+import jakarta.annotation.Nonnull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TaskForCreation(
+        @Nonnull UUID id,
+        @Nonnull UUID assigneeId,
+        @Nonnull String description,
+        @Nonnull LocalDateTime creationDate
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/replication/TaskReplicationInfo.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/domain/task/replication/TaskReplicationInfo.java
@@ -1,11 +1,11 @@
-package org.uber.popug.employee.billing.domain.task;
+package org.uber.popug.employee.billing.domain.task.replication;
 
 import jakarta.annotation.Nonnull;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record TaskInfo(
+public record TaskReplicationInfo(
         @Nonnull UUID id,
         @Nonnull UUID assigneeId,
         @Nonnull String description,

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/account/BillingAccountEntity.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/account/BillingAccountEntity.java
@@ -1,0 +1,13 @@
+package org.uber.popug.employee.billing.entity.billing.account;
+
+import jakarta.annotation.Nonnull;
+
+import java.util.UUID;
+
+public record BillingAccountEntity(
+        long id,
+        @Nonnull UUID publicId,
+        long ownerUserId,
+        long currentTotal
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/cycle/BillingCycleEntity.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/cycle/BillingCycleEntity.java
@@ -1,0 +1,26 @@
+package org.uber.popug.employee.billing.entity.billing.cycle;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BillingCycleEntity(
+        long id,
+        @Nonnull UUID publicId,
+        @Nonnull LocalDateTime startDate,
+        @Nonnull LocalDateTime endDate,
+        @Nonnull State state
+) {
+    @Getter
+    @RequiredArgsConstructor
+    public enum State {
+        ACTIVE("ACTIVE"),
+        CLOSED("CLOSED");
+
+        @Nonnull
+        private final String persistenceValue;
+    }
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/operation/BillingOperationEntity.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/billing/operation/BillingOperationEntity.java
@@ -1,0 +1,16 @@
+package org.uber.popug.employee.billing.entity.billing.operation;
+
+import jakarta.annotation.Nonnull;
+
+import java.util.UUID;
+
+public record BillingOperationEntity(
+        long id,
+        @Nonnull UUID publicId,
+        long ownerUserId,
+        @Nonnull String description,
+        long credit,
+        long debit,
+        long billingCycleId
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/composite/TaskToAssigneeEntity.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/entity/composite/TaskToAssigneeEntity.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.entity.composite;
+
+import jakarta.annotation.Nonnull;
+import org.uber.popug.employee.billing.entity.task.TaskEntity;
+import org.uber.popug.employee.billing.entity.user.UserEntity;
+
+public record TaskToAssigneeEntity(
+        @Nonnull TaskEntity task,
+        @Nonnull UserEntity taskAssignee
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskAssignmentMismatchException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskAssignmentMismatchException.java
@@ -1,0 +1,23 @@
+package org.uber.popug.employee.billing.exception;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class TaskAssignmentMismatchException extends RuntimeException {
+
+    private static final String MISMATCHING_REQUEST_ASSIGNEE_MESSAGE_TEMPLATE
+            = "Invalid assignment operation requested: Task with id %s is not assigned to user %s";
+
+    private final UUID mismatchingTaskPublicId;
+    private final UUID mismatchingAssigneePublicId;
+
+    public TaskAssignmentMismatchException(UUID requestedTaskId, UUID requestedTaskAssigneeId) {
+        super(MISMATCHING_REQUEST_ASSIGNEE_MESSAGE_TEMPLATE.formatted(requestedTaskId, requestedTaskAssigneeId));
+
+        this.mismatchingTaskPublicId = requestedTaskId;
+        this.mismatchingAssigneePublicId = requestedTaskAssigneeId;
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskNotFoundException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskNotFoundException.java
@@ -1,0 +1,21 @@
+package org.uber.popug.employee.billing.exception;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class TaskNotFoundException extends RuntimeException {
+    private final UUID publicUserId;
+    private TaskNotFoundException(String message, UUID publicUserId) {
+        super(message);
+        this.publicUserId = publicUserId;
+    }
+
+    public static TaskNotFoundException forPublicTaskId(UUID publicTaskId) {
+        return new TaskNotFoundException(
+                "The task with public ID %s does not exist.".formatted(publicTaskId),
+                publicTaskId
+        );
+    }
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskNotFoundException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/TaskNotFoundException.java
@@ -6,16 +6,16 @@ import java.util.UUID;
 
 @Getter
 public class TaskNotFoundException extends RuntimeException {
+
+    private static final String TASK_NOT_FOUND_FOR_PUBLIC_ID_MESSAGE_TEMPLATE
+            = "The task with public ID %s does not exist.";
+
     private final UUID publicUserId;
-    private TaskNotFoundException(String message, UUID publicUserId) {
-        super(message);
+
+    public TaskNotFoundException(UUID publicUserId) {
+        super(TASK_NOT_FOUND_FOR_PUBLIC_ID_MESSAGE_TEMPLATE.formatted(publicUserId));
+
         this.publicUserId = publicUserId;
     }
 
-    public static TaskNotFoundException forPublicTaskId(UUID publicTaskId) {
-        return new TaskNotFoundException(
-                "The task with public ID %s does not exist.".formatted(publicTaskId),
-                publicTaskId
-        );
-    }
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/UserNotFoundException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/UserNotFoundException.java
@@ -6,16 +6,15 @@ import java.util.UUID;
 
 @Getter
 public class UserNotFoundException extends RuntimeException {
+
+    private static final String USER_NOT_FOUND_FOR_PUBLIC_ID_MESSAGE_TEMPLATE
+            = "The user with public ID %s does not exist.";
+
     private final UUID publicUserId;
-    private UserNotFoundException(String message, UUID publicUserId) {
-        super(message);
+
+    public UserNotFoundException(UUID publicUserId) {
+        super(USER_NOT_FOUND_FOR_PUBLIC_ID_MESSAGE_TEMPLATE.formatted(publicUserId));
         this.publicUserId = publicUserId;
     }
 
-    public static UserNotFoundException forPublicUserId(UUID publicUserId) {
-        return new UserNotFoundException(
-                "The user with public ID %s does not exist.".formatted(publicUserId),
-                publicUserId
-        );
-    }
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/technical/BillingAccountUpdateFailedException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/technical/BillingAccountUpdateFailedException.java
@@ -1,0 +1,19 @@
+package org.uber.popug.employee.billing.exception.technical;
+
+import lombok.Getter;
+import org.uber.popug.employee.billing.domain.billing.PaymentData;
+
+import java.util.UUID;
+
+@Getter
+public class BillingAccountUpdateFailedException extends RuntimeException {
+
+    private final UUID accountOwner;
+    private final PaymentData failedPaymentData;
+
+    public BillingAccountUpdateFailedException(UUID accountOwner, PaymentData failedPaymentData) {
+        this.accountOwner = accountOwner;
+        this.failedPaymentData = failedPaymentData;
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/technical/NoActiveBillingCycleAvailableException.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/exception/technical/NoActiveBillingCycleAvailableException.java
@@ -1,0 +1,25 @@
+package org.uber.popug.employee.billing.exception.technical;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Getter
+public class NoActiveBillingCycleAvailableException extends RuntimeException {
+
+    private static final String NO_ACTIVE_BILLING_CYCLE_AVAILABLE_MESSAGE_TEMPLATE
+            = "There were no active billing cycles found at the time of request: %s";
+
+    private final LocalDateTime billingCycleUnavailabilityTime;
+
+    public NoActiveBillingCycleAvailableException(LocalDateTime billingCycleUnavailabilityTime) {
+        super(NO_ACTIVE_BILLING_CYCLE_AVAILABLE_MESSAGE_TEMPLATE.formatted(billingCycleUnavailabilityTime));
+
+        this.billingCycleUnavailabilityTime = billingCycleUnavailabilityTime;
+    }
+
+    public static NoActiveBillingCycleAvailableException forNowUTC() {
+        return new NoActiveBillingCycleAvailableException(LocalDateTime.now(ZoneOffset.UTC));
+    }
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskLifecycleCUDEventListener.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskLifecycleCUDEventListener.java
@@ -20,6 +20,7 @@ public class TaskLifecycleCUDEventListener {
 
     @KafkaHandler
     public void handleTaskCreatedCUDEvent(TaskCreatedReplicationEvent taskCreatedReplicationEvent) {
+        // Todo: guarantee exactly-once semantics!
         taskBillingReplicationService.replicateTaskToBilling(taskCreatedReplicationEvent);
     }
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
@@ -1,26 +1,28 @@
 package org.uber.popug.employee.billing.kafka;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 import org.uber.popug.employee.billing.kafka.event.business.TaskCompletedEvent;
 import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
 import org.uber.popug.employee.billing.kafka.event.business.TaskReassignedEvent;
+import org.uber.popug.employee.billing.service.UserAccountBillingService;
 
 @Service
+@RequiredArgsConstructor
 @KafkaListener(
         topics = "${kafka.listener.task-workflow-actions.topics}",
         groupId = "${kafka.listener.task-workflow-actions.group-id}",
-        containerFactory = "tasksBusinessWorkflowListenerContainerFactory",
-        autoStartup = "false"
+        containerFactory = "tasksBusinessWorkflowListenerContainerFactory"
 )
 public class TaskWorkflowActionsBusinessEventListener {
 
+    private final UserAccountBillingService userAccountBillingService;
+
     @KafkaHandler
     public void handleTaskCreatedBusinessEvent(TaskCreatedEvent taskCreatedEvent) {
-        throw new UnsupportedOperationException(
-                "TaskWorkflowActionsBusinessEventListener.handleTaskCreatedBusinessEvent is not implemented."
-        );
+        userAccountBillingService.billUserForTaskAssignment(taskCreatedEvent);
     }
 
     @KafkaHandler

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
@@ -1,0 +1,40 @@
+package org.uber.popug.employee.billing.kafka;
+
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.uber.popug.employee.billing.kafka.event.business.TaskCompletedEvent;
+import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
+import org.uber.popug.employee.billing.kafka.event.business.TaskReassignedEvent;
+
+@Service
+@KafkaListener(
+        topics = "${kafka.listener.task-workflow-actions.topics}",
+        groupId = "${kafka.listener.task-workflow-actions.group-id}",
+        containerFactory = "smeApplicationKafkaListenerContainerFactory",
+        autoStartup = "false"
+)
+public class TaskWorkflowActionsBusinessEventListener {
+
+    @KafkaHandler
+    public void handleTaskCreatedBusinessEvent(TaskCreatedEvent taskCreatedEvent) {
+        throw new UnsupportedOperationException(
+                "TaskWorkflowActionsBusinessEventListener.handleTaskCreatedBusinessEvent is not implemented."
+        );
+    }
+
+    @KafkaHandler
+    public void handleTaskReassignedBusinessEvent(TaskReassignedEvent taskReassignedEvent) {
+        throw new UnsupportedOperationException(
+                "TaskWorkflowActionsBusinessEventListener.handleTaskReassignedBusinessEvent is not implemented."
+        );
+    }
+
+    @KafkaHandler
+    public void handleTaskCompletedBusinessEvent(TaskCompletedEvent taskCompletedEvent) {
+        throw new UnsupportedOperationException(
+                "TaskWorkflowActionsBusinessEventListener.handleTaskCompletedBusinessEvent is not implemented."
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TaskWorkflowActionsBusinessEventListener.java
@@ -11,7 +11,7 @@ import org.uber.popug.employee.billing.kafka.event.business.TaskReassignedEvent;
 @KafkaListener(
         topics = "${kafka.listener.task-workflow-actions.topics}",
         groupId = "${kafka.listener.task-workflow-actions.group-id}",
-        containerFactory = "smeApplicationKafkaListenerContainerFactory",
+        containerFactory = "tasksBusinessWorkflowListenerContainerFactory",
         autoStartup = "false"
 )
 public class TaskWorkflowActionsBusinessEventListener {

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TasksBusinessWorkflowJsonDeserializer.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TasksBusinessWorkflowJsonDeserializer.java
@@ -1,0 +1,20 @@
+package org.uber.popug.employee.billing.kafka;
+
+import org.uber.popug.employee.billing.kafka.event.business.TaskCompletedEvent;
+import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
+import org.uber.popug.employee.billing.kafka.event.business.TaskReassignedEvent;
+
+import java.util.Map;
+
+public class TasksBusinessWorkflowJsonDeserializer extends HeaderBasedJsonDeserializer<Object> {
+    private static final Map<String, Class<?>> EXPECTED_NAME_HEADER_VALUES = Map.ofEntries(
+            Map.entry("task.created", TaskCreatedEvent.class),
+            Map.entry("task.reassigned", TaskReassignedEvent.class),
+            Map.entry("task.completed", TaskCompletedEvent.class)
+    );
+
+    public TasksBusinessWorkflowJsonDeserializer() {
+        super(EXPECTED_NAME_HEADER_VALUES);
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TasksCUDJsonDeserializer.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/TasksCUDJsonDeserializer.java
@@ -1,0 +1,17 @@
+package org.uber.popug.employee.billing.kafka;
+
+import org.uber.popug.employee.billing.kafka.event.cud.TaskCreatedReplicationEvent;
+
+import java.util.Map;
+
+public class TasksCUDJsonDeserializer extends HeaderBasedJsonDeserializer<Object> {
+
+    private static final Map<String, Class<?>> EXPECTED_NAME_HEADER_VALUES = Map.ofEntries(
+            Map.entry("task.entity.created", TaskCreatedReplicationEvent.class)
+    );
+
+    public TasksCUDJsonDeserializer() {
+        super(EXPECTED_NAME_HEADER_VALUES);
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskCompletedEvent.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskCompletedEvent.java
@@ -1,0 +1,14 @@
+package org.uber.popug.employee.billing.kafka.event.business;
+
+import jakarta.annotation.Nonnull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TaskCompletedEvent(
+        @Nonnull UUID taskId,
+        @Nonnull UUID assigneeId,
+        @Nonnull String taskDescription,
+        @Nonnull LocalDateTime completionDate
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskCreatedEvent.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskCreatedEvent.java
@@ -1,0 +1,14 @@
+package org.uber.popug.employee.billing.kafka.event.business;
+
+import jakarta.annotation.Nonnull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TaskCreatedEvent(
+        @Nonnull UUID taskId,
+        @Nonnull UUID assigneeId,
+        @Nonnull String taskDescription,
+        @Nonnull LocalDateTime creationDate
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskReassignedEvent.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/kafka/event/business/TaskReassignedEvent.java
@@ -1,0 +1,15 @@
+package org.uber.popug.employee.billing.kafka.event.business;
+
+import jakarta.annotation.Nonnull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TaskReassignedEvent(
+        @Nonnull UUID taskId,
+        @Nonnull UUID previousAssigneeId,
+        @Nonnull UUID newAssigneeId,
+        @Nonnull String taskDescription,
+        @Nonnull LocalDateTime reassignmentDate
+) {
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingAccountsPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingAccountsPersistenceMapper.java
@@ -1,0 +1,12 @@
+package org.uber.popug.employee.billing.mapping;
+
+import org.mapstruct.Mapper;
+import org.uber.popug.employee.billing.domain.billing.account.BillingAccount;
+import org.uber.popug.employee.billing.entity.billing.account.BillingAccountEntity;
+
+@Mapper
+public interface BillingAccountsPersistenceMapper {
+
+    BillingAccount toBusiness(BillingAccountEntity billingAccountEntity);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingCyclesPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingCyclesPersistenceMapper.java
@@ -1,0 +1,12 @@
+package org.uber.popug.employee.billing.mapping;
+
+import org.mapstruct.Mapper;
+import org.uber.popug.employee.billing.domain.billing.cycle.BillingCycle;
+import org.uber.popug.employee.billing.entity.billing.cycle.BillingCycleEntity;
+
+@Mapper
+public interface BillingCyclesPersistenceMapper {
+
+    BillingCycle toBusiness(BillingCycleEntity billingCycleEntity);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingOperationsPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingOperationsPersistenceMapper.java
@@ -12,8 +12,8 @@ public interface BillingOperationsPersistenceMapper {
     @Mapping(source = "data.publicId", target = "publicId")
     @Mapping(source = "ownerUser.id", target = "ownerUserId")
     @Mapping(source = "data.description", target = "description")
-    @Mapping(source = "data.credit", target = "credit")
-    @Mapping(source = "data.debit", target = "debit")
+    @Mapping(source = "data.paymentData.credit", target = "credit")
+    @Mapping(source = "data.paymentData.debit", target = "debit")
     @Mapping(source = "ownerCycle.id", target = "billingCycleId")
     BillingOperationEntity fromBusiness(BillingOperationFullData billingOperation);
 

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingOperationsPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/BillingOperationsPersistenceMapper.java
@@ -1,0 +1,20 @@
+package org.uber.popug.employee.billing.mapping;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.uber.popug.employee.billing.domain.aggregates.BillingOperationFullData;
+import org.uber.popug.employee.billing.entity.billing.operation.BillingOperationEntity;
+
+@Mapper
+public interface BillingOperationsPersistenceMapper {
+
+    @Mapping(source = "data.id", target = "id")
+    @Mapping(source = "data.publicId", target = "publicId")
+    @Mapping(source = "ownerUser.id", target = "ownerUserId")
+    @Mapping(source = "data.description", target = "description")
+    @Mapping(source = "data.credit", target = "credit")
+    @Mapping(source = "data.debit", target = "debit")
+    @Mapping(source = "ownerCycle.id", target = "billingCycleId")
+    BillingOperationEntity fromBusiness(BillingOperationFullData billingOperation);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
@@ -1,0 +1,15 @@
+package org.uber.popug.employee.billing.mapping;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.uber.popug.employee.billing.domain.task.creation.TaskForCreation;
+import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
+
+@Mapper
+public interface TasksBusinessKafkaEventMapper {
+
+    @Mapping(source = "taskId", target = "id")
+    @Mapping(source = "taskDescription", target = "description")
+    TaskForCreation toBusiness(TaskCreatedEvent taskCreatedEvent);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
@@ -2,14 +2,13 @@ package org.uber.popug.employee.billing.mapping;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.uber.popug.employee.billing.domain.task.creation.TaskForCreation;
+import org.uber.popug.employee.billing.domain.billing.creation.TaskForBillingAssignment;
 import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
 
 @Mapper
 public interface TasksBusinessKafkaEventMapper {
 
     @Mapping(source = "taskId", target = "id")
-    @Mapping(source = "taskDescription", target = "description")
-    TaskForCreation toBusiness(TaskCreatedEvent taskCreatedEvent);
+    TaskForBillingAssignment toBusiness(TaskCreatedEvent taskCreatedEvent);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksBusinessKafkaEventMapper.java
@@ -8,7 +8,7 @@ import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
 @Mapper
 public interface TasksBusinessKafkaEventMapper {
 
-    @Mapping(source = "taskId", target = "id")
+    @Mapping(source = "taskId", target = "publicId")
     TaskForBillingAssignment toBusiness(TaskCreatedEvent taskCreatedEvent);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksCUDKafkaEventMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksCUDKafkaEventMapper.java
@@ -2,7 +2,7 @@ package org.uber.popug.employee.billing.mapping;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.uber.popug.employee.billing.domain.task.TaskInfo;
+import org.uber.popug.employee.billing.domain.task.replication.TaskReplicationInfo;
 import org.uber.popug.employee.billing.kafka.event.cud.TaskCreatedReplicationEvent;
 
 @Mapper
@@ -10,6 +10,6 @@ public interface TasksCUDKafkaEventMapper {
 
     @Mapping(source = "taskId", target = "id")
     @Mapping(source = "taskDescription", target = "description")
-    TaskInfo toBusiness(TaskCreatedReplicationEvent taskCreatedReplicationEvent);
+    TaskReplicationInfo toBusiness(TaskCreatedReplicationEvent taskCreatedReplicationEvent);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
@@ -23,14 +23,22 @@ public interface TasksPersistenceMapper {
     @Mapping(source = "taskAssignee.id", target = "assignee.id")
     @Mapping(source = "taskAssignee.extPublicId", target = "assignee.extPublicId")
     @Mapping(source = "taskAssignee.login", target = "assignee.login")
-    @Mapping(source = "taskEntity", target = "task.costs", qualifiedByName = "taskToCostsMapping")
+    @Mapping(source = "taskEntity", target = "task", qualifiedByName = "taskToAssigneeEntityToBusiness")
     TaskWithAssignee toBusiness(TaskToAssigneeEntity taskEntity);
 
-    @Named("taskToCostsMapping")
+    Task.Status toBusiness(TaskEntity.Status status);
+
+    @Named("taskToAssigneeEntityToBusiness")
     @Mapping(source = "costs.assignmentCost", target = "assignmentCost")
     @Mapping(source = "costs.completionCost", target = "completionCost")
-    default Task.Costs taskToCostsMapping(TaskToAssigneeEntity taskEntity) {
-        return new Task.Costs(taskEntity.task().assignmentCost(), taskEntity.task().completionCost());
+    default Task taskToAssigneeEntityToBusiness(TaskToAssigneeEntity taskEntity) {
+        return new Task(
+                taskEntity.task().id(),
+                taskEntity.task().extPublicId(),
+                taskEntity.task().description(),
+                toBusiness(taskEntity.task().status()),
+                new Task.Costs(taskEntity.task().assignmentCost(), taskEntity.task().completionCost())
+        );
     }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
@@ -2,7 +2,9 @@ package org.uber.popug.employee.billing.mapping;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.task.Task;
 import org.uber.popug.employee.billing.entity.composite.TaskToAssigneeEntity;
 import org.uber.popug.employee.billing.entity.task.TaskEntity;
 
@@ -14,13 +16,21 @@ public interface TasksPersistenceMapper {
     @Mapping(source = "assignee.id", target = "assigneeId")
     @Mapping(source = "task.description", target = "description")
     @Mapping(source = "task.status", target = "status")
-    @Mapping(source = "task.assignmentCost", target = "assignmentCost")
-    @Mapping(source = "task.completionCost", target = "completionCost")
+    @Mapping(source = "task.costs.assignmentCost", target = "assignmentCost")
+    @Mapping(source = "task.costs.completionCost", target = "completionCost")
     TaskEntity fromBusiness(TaskWithAssignee taskWithAssignee);
 
     @Mapping(source = "taskAssignee.id", target = "assignee.id")
     @Mapping(source = "taskAssignee.extPublicId", target = "assignee.extPublicId")
     @Mapping(source = "taskAssignee.login", target = "assignee.login")
+    @Mapping(source = "taskEntity", target = "task.costs", qualifiedByName = "taskToCostsMapping")
     TaskWithAssignee toBusiness(TaskToAssigneeEntity taskEntity);
+
+    @Named("taskToCostsMapping")
+    @Mapping(source = "costs.assignmentCost", target = "assignmentCost")
+    @Mapping(source = "costs.completionCost", target = "completionCost")
+    default Task.Costs taskToCostsMapping(TaskToAssigneeEntity taskEntity) {
+        return new Task.Costs(taskEntity.task().assignmentCost(), taskEntity.task().completionCost());
+    }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/mapping/TasksPersistenceMapper.java
@@ -3,6 +3,7 @@ package org.uber.popug.employee.billing.mapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.entity.composite.TaskToAssigneeEntity;
 import org.uber.popug.employee.billing.entity.task.TaskEntity;
 
 @Mapper
@@ -16,5 +17,10 @@ public interface TasksPersistenceMapper {
     @Mapping(source = "task.assignmentCost", target = "assignmentCost")
     @Mapping(source = "task.completionCost", target = "completionCost")
     TaskEntity fromBusiness(TaskWithAssignee taskWithAssignee);
+
+    @Mapping(source = "taskAssignee.id", target = "assignee.id")
+    @Mapping(source = "taskAssignee.extPublicId", target = "assignee.extPublicId")
+    @Mapping(source = "taskAssignee.login", target = "assignee.login")
+    TaskWithAssignee toBusiness(TaskToAssigneeEntity taskEntity);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/BillingAccountRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/BillingAccountRepository.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.repository;
+
+import org.uber.popug.employee.billing.entity.billing.account.BillingAccountEntity;
+
+import java.util.Optional;
+
+public interface BillingAccountRepository {
+
+    Optional<BillingAccountEntity> subtractAccountBalanceByOwnerUser(long ownerUserId, long toSubtract);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/BillingCycleRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/BillingCycleRepository.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.repository;
+
+import org.uber.popug.employee.billing.entity.billing.cycle.BillingCycleEntity;
+
+import java.util.Optional;
+
+public interface BillingCycleRepository {
+
+    Optional<BillingCycleEntity> findActiveBillingCycle();
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/ImmutableBillingOperationsRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/ImmutableBillingOperationsRepository.java
@@ -1,0 +1,11 @@
+package org.uber.popug.employee.billing.repository;
+
+import org.uber.popug.employee.billing.entity.billing.operation.BillingOperationEntity;
+
+public interface ImmutableBillingOperationsRepository {
+
+    long generateNextDbBillingOperationId();
+
+    int appendBillingOperationEntry(BillingOperationEntity billingOperation);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/TaskRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/TaskRepository.java
@@ -2,10 +2,15 @@ package org.uber.popug.employee.billing.repository;
 
 import org.uber.popug.employee.billing.entity.task.TaskEntity;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface TaskRepository {
 
     long generateNextDbTaskId();
 
     int saveReplicated(TaskEntity task);
+
+    Optional<TaskEntity> findTaskByPublicId(UUID publicTaskId);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/TaskRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/TaskRepository.java
@@ -1,5 +1,6 @@
 package org.uber.popug.employee.billing.repository;
 
+import org.uber.popug.employee.billing.entity.composite.TaskToAssigneeEntity;
 import org.uber.popug.employee.billing.entity.task.TaskEntity;
 
 import java.util.Optional;
@@ -11,6 +12,6 @@ public interface TaskRepository {
 
     int saveReplicated(TaskEntity task);
 
-    Optional<TaskEntity> findTaskByPublicId(UUID publicTaskId);
+    Optional<TaskToAssigneeEntity> findTaskToAssigneeByPublicTaskId(UUID publicTaskId);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientBillingAccountRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientBillingAccountRepository.java
@@ -1,0 +1,33 @@
+package org.uber.popug.employee.billing.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.uber.popug.employee.billing.entity.billing.account.BillingAccountEntity;
+import org.uber.popug.employee.billing.repository.BillingAccountRepository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class JdbcClientBillingAccountRepository implements BillingAccountRepository {
+
+    private static final String UPDATE_BILLING_ACCOUNT_BALANCE_BY_USER_ID_SQL = /* language=postgresql */
+        """
+        UPDATE EMPLOYEE_BILLING.billing_accounts
+        SET current_total = current_total - :toSubtract + :toAdd
+        WHERE owner_user_id = :ownerUserId
+        RETURNING id, public_id, owner_user_id, current_total
+        """;
+
+    private final JdbcClient jdbcClient;
+
+    @Override
+    public Optional<BillingAccountEntity> subtractAccountBalanceByOwnerUser(long ownerUserId, long toSubtract) {
+        return jdbcClient.sql(UPDATE_BILLING_ACCOUNT_BALANCE_BY_USER_ID_SQL)
+                .param("ownerUserId", ownerUserId)
+                .param("toSubtract", toSubtract)
+                .param("toAdd", 0L)
+                .query(BillingAccountEntity.class)
+                .optional();
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientBillingCycleRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientBillingCycleRepository.java
@@ -1,0 +1,28 @@
+package org.uber.popug.employee.billing.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.uber.popug.employee.billing.entity.billing.cycle.BillingCycleEntity;
+import org.uber.popug.employee.billing.repository.BillingCycleRepository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class JdbcClientBillingCycleRepository implements BillingCycleRepository {
+
+    private static final String SELECT_ACTIVE_BILLING_CYCLE_SQL = /* language=postgresql */
+            """
+            SELECT id, public_id, start_date, end_date, state
+            FROM EMPLOYEE_BILLING.billing_cycles
+            WHERE state = 'ACTIVE'
+            """;
+
+    private final JdbcClient jdbcClient;
+
+    @Override
+    public Optional<BillingCycleEntity> findActiveBillingCycle() {
+        return jdbcClient.sql(SELECT_ACTIVE_BILLING_CYCLE_SQL)
+                .query(BillingCycleEntity.class)
+                .optional();
+    }
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientImmutableBillingOperationsRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientImmutableBillingOperationsRepository.java
@@ -1,0 +1,52 @@
+package org.uber.popug.employee.billing.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.uber.popug.employee.billing.entity.billing.operation.BillingOperationEntity;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class JdbcClientImmutableBillingOperationsRepository implements ImmutableBillingOperationsRepository {
+
+    private static final String GENERATE_NEXT_BILLING_OPERATION_ID_SQL = /* language=postgresql */
+            """
+            SELECT NEXTVAL('EMPLOYEE_BILLING.billing_operations_id_seq')
+            """;
+
+    private static final String INSERT_BILLING_OPERATION_LOG_ENTRY_SQL = /* language=postgresql */
+            """
+            INSERT INTO EMPLOYEE_BILLING.BILLING_OPERATIONS
+                (id, public_id, owner_user_id, description, credit, debit, billing_cycle_id)
+            VALUES
+                (:id, :publicId, :ownerUserId, :description, :credit, :debit, :billingCycleId)
+            """;
+
+    private final JdbcClient jdbcClient;
+
+    @Override
+    public long generateNextDbBillingOperationId() {
+        return jdbcClient.sql(GENERATE_NEXT_BILLING_OPERATION_ID_SQL)
+                .query(Long.class)
+                .single();
+    }
+
+    @Override
+    public int appendBillingOperationEntry(BillingOperationEntity billingOperation) {
+        return jdbcClient.sql(INSERT_BILLING_OPERATION_LOG_ENTRY_SQL)
+                .params(
+                        Map.ofEntries(
+                                Map.entry("id", billingOperation.id()),
+                                Map.entry("publicId", billingOperation.publicId()),
+                                Map.entry("ownerUserId", billingOperation.ownerUserId()),
+                                Map.entry("description", billingOperation.description()),
+                                Map.entry("credit", billingOperation.credit()),
+                                Map.entry("debit", billingOperation.debit()),
+                                Map.entry("billingCycleId", billingOperation.billingCycleId())
+                        )
+                )
+                .update();
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientTaskRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientTaskRepository.java
@@ -71,7 +71,7 @@ public class JdbcClientTaskRepository implements TaskRepository {
                                         rs.getObject("ext_public_task_id", UUID.class),
                                         rs.getLong("assignee_id"),
                                         rs.getString("task_description"),
-                                        rs.getObject("task_status", TaskEntity.Status.class),
+                                        TaskEntity.Status.valueOf(rs.getString("task_status")),
                                         rs.getLong("task_assignment_cost"),
                                         rs.getLong("task_completion_cost")
                                 ),

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientTaskRepository.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/repository/impl/JdbcClientTaskRepository.java
@@ -5,6 +5,9 @@ import org.springframework.jdbc.core.simple.JdbcClient;
 import org.uber.popug.employee.billing.entity.task.TaskEntity;
 import org.uber.popug.employee.billing.repository.TaskRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @RequiredArgsConstructor
 public class JdbcClientTaskRepository implements TaskRepository {
 
@@ -20,6 +23,14 @@ public class JdbcClientTaskRepository implements TaskRepository {
             VALUES
                 (:id, :extPublicId, :assigneeId, :description, :assignmentCost, :completionCost)
             """;
+
+    private static final String FIND_TASK_BY_PUBLIC_ID_SQL = /* language=postgresql */
+            """
+            SELECT id, ext_public_id, assignee_id, description, status, assignment_cost, completion_cost
+            FROM EMPLOYEE_BILLING.TASKS
+            WHERE ext_public_id = :extPublicId
+            """;
+
 
     private final JdbcClient jdbcClient;
 
@@ -40,5 +51,13 @@ public class JdbcClientTaskRepository implements TaskRepository {
                 .param("assignmentCost", task.assignmentCost())
                 .param("completionCost", task.completionCost())
                 .update();
+    }
+
+    @Override
+    public Optional<TaskEntity> findTaskByPublicId(UUID publicTaskId) {
+        return jdbcClient.sql(FIND_TASK_BY_PUBLIC_ID_SQL)
+                .param("extPublicId", publicTaskId)
+                .query(TaskEntity.class)
+                .optional();
     }
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/BillingAccountManagementService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/BillingAccountManagementService.java
@@ -1,0 +1,10 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.domain.aggregates.BillingAccountWithOwner;
+import org.uber.popug.employee.billing.domain.aggregates.PaymentDataWithUser;
+
+public interface BillingAccountManagementService {
+
+    BillingAccountWithOwner payUserForInitialAssignment(PaymentDataWithUser paymentDataWithUser);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/BillingOperationLogService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/BillingOperationLogService.java
@@ -1,0 +1,10 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.domain.aggregates.BillingOperationFullData;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+
+public interface BillingOperationLogService {
+
+    BillingOperationFullData createBillingOperationLogEntry(TaskWithAssignee taskWithAssignee);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TaskBillingAssignmentService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TaskBillingAssignmentService.java
@@ -1,10 +1,10 @@
 package org.uber.popug.employee.billing.service;
 
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
-import org.uber.popug.employee.billing.domain.task.TaskInfo;
+import org.uber.popug.employee.billing.domain.task.replication.TaskReplicationInfo;
 
 public interface TaskBillingAssignmentService {
 
-    TaskWithAssignee assembleTaskWithAssignee(TaskInfo taskInfo);
+    TaskWithAssignee assembleTaskWithAssignee(TaskReplicationInfo taskReplicationInfo);
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TaskBillingOperationAssemblingService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TaskBillingOperationAssemblingService.java
@@ -1,0 +1,10 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperation;
+
+public interface TaskBillingOperationAssemblingService {
+
+    BillingOperation assembleForNewlyAssignedTask(TaskWithAssignee task);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TransactionalAccountingService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/TransactionalAccountingService.java
@@ -1,0 +1,9 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+
+public interface TransactionalAccountingService {
+
+    void billForNewlyAssignedTask(TaskWithAssignee taskWithAssignee);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/UserAccountBillingService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/UserAccountBillingService.java
@@ -1,0 +1,9 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
+
+public interface UserAccountBillingService {
+
+    void billUserForTaskAssignment(TaskCreatedEvent taskCreatedEvent);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/UserAccountMembershipCheckingService.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/UserAccountMembershipCheckingService.java
@@ -1,0 +1,10 @@
+package org.uber.popug.employee.billing.service;
+
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.creation.TaskForBillingAssignment;
+
+public interface UserAccountMembershipCheckingService {
+
+    TaskWithAssignee retrieveTaskWithAssigneeIfRequestValid(TaskForBillingAssignment task);
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/BillingAccountManagementServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/BillingAccountManagementServiceImpl.java
@@ -1,0 +1,40 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.aggregates.BillingAccountWithOwner;
+import org.uber.popug.employee.billing.domain.aggregates.PaymentDataWithUser;
+import org.uber.popug.employee.billing.domain.billing.account.BillingAccount;
+import org.uber.popug.employee.billing.exception.technical.BillingAccountUpdateFailedException;
+import org.uber.popug.employee.billing.mapping.BillingAccountsPersistenceMapper;
+import org.uber.popug.employee.billing.repository.BillingAccountRepository;
+import org.uber.popug.employee.billing.service.BillingAccountManagementService;
+
+@RequiredArgsConstructor
+public class BillingAccountManagementServiceImpl implements BillingAccountManagementService {
+
+    private final BillingAccountRepository billingAccountRepository;
+    private final BillingAccountsPersistenceMapper billingAccountsPersistenceMapper;
+
+    @Override
+    public BillingAccountWithOwner payUserForInitialAssignment(PaymentDataWithUser paymentDataWithUser) {
+        final var updatedBillingAccount = subtractInitialAssignmentIfPossible(paymentDataWithUser);
+        return new BillingAccountWithOwner(updatedBillingAccount, paymentDataWithUser.relatedUser());
+    }
+
+    private BillingAccount subtractInitialAssignmentIfPossible(PaymentDataWithUser paymentDataWithUser) {
+        final var updatedBillingAccountEntityOpt = billingAccountRepository.subtractAccountBalanceByOwnerUser(
+                paymentDataWithUser.relatedUser().id(),
+                paymentDataWithUser.data().credit()
+        );
+
+        final var updatedBillingAccountEntity = updatedBillingAccountEntityOpt.orElseThrow(
+                () ->  new BillingAccountUpdateFailedException(
+                        paymentDataWithUser.relatedUser().extPublicId(),
+                        paymentDataWithUser.data()
+                )
+        );
+
+        return billingAccountsPersistenceMapper.toBusiness(updatedBillingAccountEntity);
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/BillingOperationLogServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/BillingOperationLogServiceImpl.java
@@ -1,0 +1,39 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.aggregates.BillingCycleProvider;
+import org.uber.popug.employee.billing.domain.aggregates.BillingOperationFullData;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
+import org.uber.popug.employee.billing.service.BillingOperationLogService;
+import org.uber.popug.employee.billing.service.TaskBillingOperationAssemblingService;
+
+@RequiredArgsConstructor
+public class BillingOperationLogServiceImpl implements BillingOperationLogService {
+
+    private final TaskBillingOperationAssemblingService billingOperationAssemblingService;
+    private final BillingCycleProvider billingCycleProvider;
+    private final BillingOperationsPersistenceMapper billingOperationsPersistenceMapper;
+    private final ImmutableBillingOperationsRepository billingOperationsRepository;
+
+    @Override
+    public BillingOperationFullData createBillingOperationLogEntry(TaskWithAssignee taskWithAssignee) {
+
+        final var billingOperationAggregate = retrieveBillingOperationAggregate(taskWithAssignee);
+        final var billingOperationEntity = billingOperationsPersistenceMapper.fromBusiness(billingOperationAggregate);
+        billingOperationsRepository.appendBillingOperationEntry(billingOperationEntity);
+
+        return billingOperationAggregate;
+    }
+
+    private BillingOperationFullData retrieveBillingOperationAggregate(TaskWithAssignee taskWithAssignee) {
+        final var billingOperation = billingOperationAssemblingService.assembleForNewlyAssignedTask(taskWithAssignee);
+        return BillingOperationFullData.assembleBillingOperationLogEntry(
+                billingOperation,
+                taskWithAssignee.assignee(),
+                billingCycleProvider
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingAssignmentServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingAssignmentServiceImpl.java
@@ -37,7 +37,7 @@ public class TaskBillingAssignmentServiceImpl implements TaskBillingAssignmentSe
     private User getAssigneeIfExistsByPublicId(UUID publicUserId) {
         final var taskAssigneeEntityOptional = userRepository.findByPublicId(publicUserId);
         if (taskAssigneeEntityOptional.isEmpty()) {
-            throw UserNotFoundException.forPublicUserId(publicUserId);
+            throw new UserNotFoundException(publicUserId);
         }
 
         return usersPersistenceMapper.toBusiness(taskAssigneeEntityOptional.get());

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingAssignmentServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingAssignmentServiceImpl.java
@@ -5,7 +5,7 @@ import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
 import org.uber.popug.employee.billing.domain.task.Task;
 import org.uber.popug.employee.billing.domain.task.TaskCostsProvider;
 import org.uber.popug.employee.billing.domain.task.TaskIdProvider;
-import org.uber.popug.employee.billing.domain.task.TaskInfo;
+import org.uber.popug.employee.billing.domain.task.replication.TaskReplicationInfo;
 import org.uber.popug.employee.billing.domain.user.User;
 import org.uber.popug.employee.billing.exception.UserNotFoundException;
 import org.uber.popug.employee.billing.mapping.UsersPersistenceMapper;
@@ -23,12 +23,12 @@ public class TaskBillingAssignmentServiceImpl implements TaskBillingAssignmentSe
     private final TaskCostsProvider taskCostsProvider;
 
     @Override
-    public TaskWithAssignee assembleTaskWithAssignee(TaskInfo taskInfo) {
-        final var taskAssignee = getAssigneeIfExistsByPublicId(taskInfo.assigneeId());
+    public TaskWithAssignee assembleTaskWithAssignee(TaskReplicationInfo taskReplicationInfo) {
+        final var taskAssignee = getAssigneeIfExistsByPublicId(taskReplicationInfo.assigneeId());
         final var replicatedTask = Task.replicate(
                 taskIdProvider,
                 taskCostsProvider,
-                taskInfo
+                taskReplicationInfo
         );
 
         return new TaskWithAssignee(replicatedTask, taskAssignee);

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingOperationAssemblingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TaskBillingOperationAssemblingServiceImpl.java
@@ -1,0 +1,25 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperation;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationDescriptionBuilder;
+import org.uber.popug.employee.billing.domain.billing.operation.BillingOperationIdProvider;
+import org.uber.popug.employee.billing.service.TaskBillingOperationAssemblingService;
+
+@RequiredArgsConstructor
+public class TaskBillingOperationAssemblingServiceImpl implements TaskBillingOperationAssemblingService {
+
+    private final BillingOperationIdProvider billingOperationIdProvider;
+    private final BillingOperationDescriptionBuilder<TaskWithAssignee> taskWithAssigneeDescriptionBuilder;
+
+    @Override
+    public BillingOperation assembleForNewlyAssignedTask(TaskWithAssignee task) {
+        return BillingOperation.forTaskWithAssignee(
+                billingOperationIdProvider,
+                taskWithAssigneeDescriptionBuilder,
+                task
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
@@ -2,37 +2,19 @@ package org.uber.popug.employee.billing.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.uber.popug.employee.billing.domain.aggregates.BillingCycleProvider;
-import org.uber.popug.employee.billing.domain.aggregates.BillingOperationFullData;
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
-import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
-import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
-import org.uber.popug.employee.billing.service.TaskBillingOperationAssemblingService;
+import org.uber.popug.employee.billing.service.BillingOperationLogService;
 import org.uber.popug.employee.billing.service.TransactionalAccountingService;
 
 @RequiredArgsConstructor
 public class TransactionalAccountingServiceImpl implements TransactionalAccountingService {
 
-    private final TaskBillingOperationAssemblingService billingOperationAssemblingService;
-    private final BillingCycleProvider billingCycleProvider;
-    private final BillingOperationsPersistenceMapper billingOperationsPersistenceMapper;
-    private final ImmutableBillingOperationsRepository billingOperationsRepository;
+    private final BillingOperationLogService billingOperationLogService;
 
     @Override
     @Transactional
     public void billForNewlyAssignedTask(TaskWithAssignee taskWithAssignee) {
-        final var billingOperationAggregate = retrieveBillingOperationAggregate(taskWithAssignee);
-        final var billingOperationEntity = billingOperationsPersistenceMapper.fromBusiness(billingOperationAggregate);
-        billingOperationsRepository.appendBillingOperationEntry(billingOperationEntity);
-    }
-
-    private BillingOperationFullData retrieveBillingOperationAggregate(TaskWithAssignee taskWithAssignee) {
-        final var billingOperation = billingOperationAssemblingService.assembleForNewlyAssignedTask(taskWithAssignee);
-        return BillingOperationFullData.assembleBillingOperationLogEntry(
-                billingOperation,
-                taskWithAssignee.assignee(),
-                billingCycleProvider
-        );
+        billingOperationLogService.createBillingOperationLogEntry(taskWithAssignee);
     }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
@@ -1,0 +1,38 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.uber.popug.employee.billing.domain.aggregates.BillingCycleProvider;
+import org.uber.popug.employee.billing.domain.aggregates.BillingOperationFullData;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.mapping.BillingOperationsPersistenceMapper;
+import org.uber.popug.employee.billing.repository.ImmutableBillingOperationsRepository;
+import org.uber.popug.employee.billing.service.TaskBillingOperationAssemblingService;
+import org.uber.popug.employee.billing.service.TransactionalAccountingService;
+
+@RequiredArgsConstructor
+public class TransactionalAccountingServiceImpl implements TransactionalAccountingService {
+
+    private final TaskBillingOperationAssemblingService billingOperationAssemblingService;
+    private final BillingCycleProvider billingCycleProvider;
+    private final BillingOperationsPersistenceMapper billingOperationsPersistenceMapper;
+    private final ImmutableBillingOperationsRepository billingOperationsRepository;
+
+    @Override
+    @Transactional
+    public void billForNewlyAssignedTask(TaskWithAssignee taskWithAssignee) {
+        final var billingOperationAggregate = retrieveBillingOperationAggregate(taskWithAssignee);
+        final var billingOperationEntity = billingOperationsPersistenceMapper.fromBusiness(billingOperationAggregate);
+        billingOperationsRepository.appendBillingOperationEntry(billingOperationEntity);
+    }
+
+    private BillingOperationFullData retrieveBillingOperationAggregate(TaskWithAssignee taskWithAssignee) {
+        final var billingOperation = billingOperationAssemblingService.assembleForNewlyAssignedTask(taskWithAssignee);
+        return BillingOperationFullData.assembleBillingOperationLogEntry(
+                billingOperation,
+                taskWithAssignee.assignee(),
+                billingCycleProvider
+        );
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/TransactionalAccountingServiceImpl.java
@@ -2,7 +2,10 @@ package org.uber.popug.employee.billing.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.uber.popug.employee.billing.domain.aggregates.PaymentDataWithUser;
 import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.PaymentData;
+import org.uber.popug.employee.billing.service.BillingAccountManagementService;
 import org.uber.popug.employee.billing.service.BillingOperationLogService;
 import org.uber.popug.employee.billing.service.TransactionalAccountingService;
 
@@ -10,11 +13,18 @@ import org.uber.popug.employee.billing.service.TransactionalAccountingService;
 public class TransactionalAccountingServiceImpl implements TransactionalAccountingService {
 
     private final BillingOperationLogService billingOperationLogService;
+    private final BillingAccountManagementService billingAccountManagementService;
 
     @Override
     @Transactional
     public void billForNewlyAssignedTask(TaskWithAssignee taskWithAssignee) {
         billingOperationLogService.createBillingOperationLogEntry(taskWithAssignee);
+
+        final var paymentData = new PaymentDataWithUser(
+                PaymentData.newCreditData(taskWithAssignee.task().costs().assignmentCost()),
+                taskWithAssignee.assignee()
+        );
+        billingAccountManagementService.payUserForInitialAssignment(paymentData);
     }
 
 }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountBillingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountBillingServiceImpl.java
@@ -1,0 +1,37 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.kafka.event.business.TaskCreatedEvent;
+import org.uber.popug.employee.billing.mapping.TasksBusinessKafkaEventMapper;
+import org.uber.popug.employee.billing.service.TransactionalAccountingService;
+import org.uber.popug.employee.billing.service.UserAccountBillingService;
+import org.uber.popug.employee.billing.service.UserAccountMembershipCheckingService;
+
+@RequiredArgsConstructor
+public class UserAccountBillingServiceImpl implements UserAccountBillingService {
+
+    private final TasksBusinessKafkaEventMapper tasksBusinessKafkaEventMapper;
+    private final UserAccountMembershipCheckingService accountMembershipCheckingService;
+    private final TransactionalAccountingService transactionalAccountingService;
+
+    @Override
+    public void billUserForTaskAssignment(TaskCreatedEvent taskCreatedEvent) {
+        /*
+         * Algorithm:
+         * 1) Map Kafka TaskCreatedEvent into a task + assignee business type.
+         * 2) Find the task and its assignee in the DB:
+         *      1) Get TaskEntity from DB.
+         *      2) Make sure the requested and actual assignees match.
+         *      3) Make sure the user with requested id exists with an account (composite entity).
+         * 3) Perform transactional accounting:
+         *      1) Add task action to the immutable transactions log.
+         *      2) Update user balance.
+         */
+        final var taskForBillingCandidate = tasksBusinessKafkaEventMapper.toBusiness(taskCreatedEvent);
+        final var taskForBilling = accountMembershipCheckingService
+                .retrieveTaskWithAssigneeIfRequestValid(taskForBillingCandidate);
+
+        transactionalAccountingService.billForNewlyAssignedTask(taskForBilling);
+    }
+
+}

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountMembershipCheckingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountMembershipCheckingServiceImpl.java
@@ -40,6 +40,9 @@ public class UserAccountMembershipCheckingServiceImpl implements UserAccountMemb
         final var requestedTaskWithActualAssignee = retrieveTaskWithAssigneeIfPossible(task.publicId());
         final var requestedTaskAssignee = retrieveAssigneeIfPossibleForPublicId(task.assigneeId());
 
+        // Todo: ensure these 2 cases are impossible to co-exist:
+        // 1) Assignee info arrived with a delay (actually the task has been reassigned, potentially multiple times).
+        // 2) The task has never been assigned to that specific user.
         if (requestedAssigneeMismatchesActualAssignee(requestedTaskWithActualAssignee, requestedTaskAssignee)) {
             throw new TaskAssignmentMismatchException(task.publicId(), task.assigneeId());
         }

--- a/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountMembershipCheckingServiceImpl.java
+++ b/employee-billing/src/main/java/org/uber/popug/employee/billing/service/impl/UserAccountMembershipCheckingServiceImpl.java
@@ -1,0 +1,79 @@
+package org.uber.popug.employee.billing.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.uber.popug.employee.billing.domain.aggregates.TaskWithAssignee;
+import org.uber.popug.employee.billing.domain.billing.creation.TaskForBillingAssignment;
+import org.uber.popug.employee.billing.domain.user.User;
+import org.uber.popug.employee.billing.exception.TaskAssignmentMismatchException;
+import org.uber.popug.employee.billing.exception.TaskNotFoundException;
+import org.uber.popug.employee.billing.exception.UserNotFoundException;
+import org.uber.popug.employee.billing.mapping.TasksPersistenceMapper;
+import org.uber.popug.employee.billing.mapping.UsersPersistenceMapper;
+import org.uber.popug.employee.billing.repository.TaskRepository;
+import org.uber.popug.employee.billing.repository.UserRepository;
+import org.uber.popug.employee.billing.service.UserAccountMembershipCheckingService;
+
+import java.util.Objects;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class UserAccountMembershipCheckingServiceImpl implements UserAccountMembershipCheckingService {
+
+    private final TaskRepository taskRepository;
+    private final UserRepository userRepository;
+    private final TasksPersistenceMapper tasksPersistenceMapper;
+    private final UsersPersistenceMapper usersPersistenceMapper;
+
+    /**
+     * Algorithm:
+     * <ol>
+     *     <li>Get TaskWithAssignee by requested public task id (retrieve actual assignee of the given task).</li>
+     *     <li>Get assignee by requested public task id.</li>
+     *     <li>Check that requested and actual assignees match, otherwise request data is invalid.</li>
+     * </ol>
+     *
+     * @return A {@link TaskWithAssignee} object containing all the necessary data about the task and its assignee in
+     * the system.
+     */
+    @Override
+    public TaskWithAssignee retrieveTaskWithAssigneeIfRequestValid(TaskForBillingAssignment task) {
+        final var requestedTaskWithActualAssignee = retrieveTaskWithAssigneeIfPossible(task.publicId());
+        final var requestedTaskAssignee = retrieveAssigneeIfPossibleForPublicId(task.assigneeId());
+
+        if (requestedAssigneeMismatchesActualAssignee(requestedTaskWithActualAssignee, requestedTaskAssignee)) {
+            throw new TaskAssignmentMismatchException(task.publicId(), task.assigneeId());
+        }
+
+        return requestedTaskWithActualAssignee;
+    }
+
+    private TaskWithAssignee retrieveTaskWithAssigneeIfPossible(UUID publicTaskId) {
+        final var taskToAssigneeEntityForPublicIdOpt = taskRepository.findTaskToAssigneeByPublicTaskId(publicTaskId);
+
+        if (taskToAssigneeEntityForPublicIdOpt.isEmpty()) {
+            throw new TaskNotFoundException(publicTaskId);
+        }
+        final var taskToAssigneeEntityForPublicId = taskToAssigneeEntityForPublicIdOpt.get();
+
+        return tasksPersistenceMapper.toBusiness(taskToAssigneeEntityForPublicId);
+    }
+
+    private User retrieveAssigneeIfPossibleForPublicId(UUID publicAssigneeId) {
+        final var assigneeEntityForRequestedTaskOptional = userRepository.findByPublicId(publicAssigneeId);
+
+        if (assigneeEntityForRequestedTaskOptional.isEmpty()) {
+            throw new UserNotFoundException(publicAssigneeId);
+        }
+        final var assigneeEntityForRequestedTask = assigneeEntityForRequestedTaskOptional.get();
+
+        return usersPersistenceMapper.toBusiness(assigneeEntityForRequestedTask);
+    }
+
+    private boolean requestedAssigneeMismatchesActualAssignee(
+            TaskWithAssignee requestedTaskWithAssignee,
+            User actualAssignee
+    ) {
+        return !Objects.equals(requestedTaskWithAssignee.assignee().extPublicId(), actualAssignee.extPublicId());
+    }
+
+}

--- a/task-tracker/src/main/java/org/uber/popug/task/tracker/service/impl/TaskAddingServiceImpl.java
+++ b/task-tracker/src/main/java/org/uber/popug/task/tracker/service/impl/TaskAddingServiceImpl.java
@@ -1,6 +1,7 @@
 package org.uber.popug.task.tracker.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.uber.popug.task.tracker.kafka.producer.TasksBusinessEventProducer;
 import org.uber.popug.task.tracker.kafka.producer.TasksCUDEventProducer;
 import org.uber.popug.task.tracker.mapping.TasksDtoMapper;
@@ -13,6 +14,8 @@ import org.uber.popug.task.tracker.service.TaskAddingService;
 @RequiredArgsConstructor
 public class TaskAddingServiceImpl implements TaskAddingService {
 
+    private static final long SIMULATION_TIMEOUT_MILLIS_TO_TEMPORARILY_SLOW_DOWN_BUSINESS_EVENT = 500L;
+
     private final TasksDtoMapper tasksDtoMapper;
     private final TaskAssignmentService taskAssignmentService;
     private final TaskRepository taskRepository;
@@ -20,12 +23,15 @@ public class TaskAddingServiceImpl implements TaskAddingService {
     private final TasksCUDEventProducer tasksCUDEventProducer;
 
     @Override
+    @SneakyThrows
     public PostAddTaskResponseDto addNewTask(PostAddTaskRequestDto postTasksRequestDto) {
         final var taskForCreation = tasksDtoMapper.postTaskRequestsDtoToBusiness(postTasksRequestDto);
         final var assignedTask = taskAssignmentService.assignNewTask(taskForCreation);
         taskRepository.add(assignedTask);
-        tasksBusinessEventProducer.sendTaskCreationEvent(assignedTask);
         tasksCUDEventProducer.sendTaskCreatedReplicationEvent(assignedTask);
+        // Todo: get rid of this monstrosity, currently solves receiving CUD before business in the worst possible way.
+        Thread.sleep(SIMULATION_TIMEOUT_MILLIS_TO_TEMPORARILY_SLOW_DOWN_BUSINESS_EVENT);
+        tasksBusinessEventProducer.sendTaskCreationEvent(assignedTask);
 
         return tasksDtoMapper.postTasksResponseDtoFromBusiness(assignedTask);
     }


### PR DESCRIPTION
Implemented a Kafka listener for business TaskCreatedEvent:
- Configured the necessary listener.
- Added task handling logic.

Temporary bad solution:
- Thread.sleep for 500 milliseconds to guarantee ordering of TaskCreatedReplicationEvent (CUD) before TaskCreatedEvent (business).

Added TODOs:
- Guarantee TaskCreatedReplicationEvent CUD events are always applied before any related business events.
- Ensure exactly-once delivery in listeners.
- Guarantee task business event chronological ordering.

Closes Feature/POPUG-14.